### PR TITLE
Fixed Dev-Quiz Instruction Typos

### DIFF
--- a/DevQuiz/index.html
+++ b/DevQuiz/index.html
@@ -65,9 +65,9 @@
                 <ul>
                     <li>If you are not programmer ( or related to field of <span class="is-love">Computer Science❤️</span> ), this game might be not for you as this game is for programmers.</li>
                     <li>The game presents questions related to programming or computer science, each with four answer options.</li>
-                    <li>layers must select the option they believe is the correct answer.</li>
+                    <li>Payers must select the option they believe is the correct answer.</li>
                     <li>Correct answers are worth 10 points, and there's no penalty for wrong answers.</li>
-                    <li>The final score is determined by the number of correct answers, with a maximum of 10 points per question</li>
+                    <li>The final score is determined by the number of correct answers, with a maximum of 10 points per question.</li>
                     <li>At the end of the game, players will see their total score as an indicator of their programming knowledge.</li>
                 </ul>
             </h2>


### PR DESCRIPTION
Changes 'layers' in line three on instructions to 'Players' and also added a full stop in second last instruction.